### PR TITLE
Underscore matched none to many characters

### DIFF
--- a/src/main/java/io/ebeaninternal/server/el/ElMatchBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElMatchBuilder.java
@@ -181,7 +181,7 @@ class ElMatchBuilder {
         if (ch == '%') {
           regex.appendPattern(".*");
         } else if (ch == '_') {
-          regex.appendPattern(".*");
+          regex.appendPattern(".");
         } else {
           regex.appendLiteral(ch);
         }

--- a/src/test/java/org/tests/query/TestInMemoryQuery.java
+++ b/src/test/java/org/tests/query/TestInMemoryQuery.java
@@ -441,6 +441,11 @@ public class TestInMemoryQuery extends BaseTestCase {
     testQuery(condition -> {
       condition.like("name", "F_o%");
     }, fiona);
+    
+    // No customer, because there is no three char long customer.
+    testQuery(condition -> {
+      condition.like("name", "No_");
+    });
   }
 
   @Test


### PR DESCRIPTION
As the underscore (`_`) is defined in
http://www.h2database.com/html/grammar.html#condition_right_hand_side
as the matcher for one single character (not more, not less), the regex pattern has to be changed.