### PR TITLE
ENH: Queries are cancelable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.197</version>
+      <version>1.4.199</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/io/ebean/CancelableQuery.java
+++ b/src/main/java/io/ebean/CancelableQuery.java
@@ -1,4 +1,4 @@
-package io.ebeaninternal.server.query;
+package io.ebean;
 
 /**
  * Defines a cancelable query.

--- a/src/main/java/io/ebean/DtoQuery.java
+++ b/src/main/java/io/ebean/DtoQuery.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
  *
  * }</pre>
  */
-public interface DtoQuery<T> {
+public interface DtoQuery<T> extends CancelableQuery {
 
   /**
    * Execute the query returning a list.

--- a/src/main/java/io/ebean/Query.java
+++ b/src/main/java/io/ebean/Query.java
@@ -176,7 +176,7 @@ import java.util.function.Predicate;
  *
  * @param <T> the type of Entity bean this query will fetch.
  */
-public interface Query<T> {
+public interface Query<T> extends CancelableQuery {
 
   /**
    * For update mode.
@@ -258,15 +258,6 @@ public interface Query<T> {
    * }</pre>
    */
   UpdateQuery<T> asUpdate();
-
-  /**
-   * Cancel the query execution if supported by the underlying database and
-   * driver.
-   * <p>
-   * This must be called from a different thread to the query executor.
-   * </p>
-   */
-  void cancel();
 
   /**
    * Return a copy of the query.

--- a/src/main/java/io/ebean/SqlQuery.java
+++ b/src/main/java/io/ebean/SqlQuery.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
  *
  * }</pre>
  */
-public interface SqlQuery extends Serializable {
+public interface SqlQuery extends Serializable, CancelableQuery {
 
   /**
    * Execute the query returning a list.

--- a/src/main/java/io/ebean/util/JdbcClose.java
+++ b/src/main/java/io/ebean/util/JdbcClose.java
@@ -66,4 +66,17 @@ public class JdbcClose {
       logger.warn("Error on connection rollback", e);
     }
   }
+
+  /**
+   * Cancels the statement
+   */
+  public static void cancel(Statement stmt) {
+    try {
+      if (stmt != null) {
+        stmt.cancel();
+      }
+    } catch (SQLException e) {
+      logger.warn("Error on cancelling statement", e);
+    }
+  }
 }

--- a/src/main/java/io/ebeaninternal/api/SpiCancelableQuery.java
+++ b/src/main/java/io/ebeaninternal/api/SpiCancelableQuery.java
@@ -1,0 +1,26 @@
+package io.ebeaninternal.api;
+
+import javax.persistence.PersistenceException;
+
+import io.ebean.CancelableQuery;
+
+/**
+ * Cancellable query, that has a delegate.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public interface SpiCancelableQuery extends CancelableQuery {
+
+  /**
+   * Checks if the query was cancelled.
+   * @throws PersistenceException if query was cancelled.
+   */
+  void checkCancelled();
+
+  /**
+   * Set the underlying cancelable query (with the PreparedStatement).
+   */
+  void setCancelableQuery(CancelableQuery cancelableQuery);
+
+}

--- a/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -17,7 +17,6 @@ import io.ebeaninternal.server.core.SpiOrmQueryRequest;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
 import io.ebeaninternal.server.deploy.TableJoin;
-import io.ebeaninternal.server.query.CancelableQuery;
 import io.ebeaninternal.server.querydefn.NaturalKeyBindParam;
 import io.ebeaninternal.server.querydefn.OrmQueryDetail;
 import io.ebeaninternal.server.querydefn.OrmUpdateProperties;
@@ -30,7 +29,7 @@ import java.util.Set;
 /**
  * Object Relational query - Internal extension to Query object.
  */
-public interface SpiQuery<T> extends Query<T>, TxnProfileEventCodes {
+public interface SpiQuery<T> extends Query<T>, TxnProfileEventCodes, SpiCancelableQuery {
 
   enum Mode {
     NORMAL(false), LAZYLOAD_MANY(false), LAZYLOAD_BEAN(true), REFRESH_BEAN(true);
@@ -835,16 +834,6 @@ public interface SpiQuery<T> extends Query<T>, TxnProfileEventCodes {
    * Read the readEvent for future queries (null otherwise).
    */
   ReadEvent getFutureFetchAudit();
-
-  /**
-   * Set the underlying cancelable query (with the PreparedStatement).
-   */
-  void setCancelableQuery(CancelableQuery cancelableQuery);
-
-  /**
-   * Return true if this query has been cancelled.
-   */
-  boolean isCancelled();
 
   /**
    * Return the base table to use if user defined on the query.

--- a/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
+++ b/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
@@ -3,7 +3,7 @@ package io.ebeaninternal.api;
 /**
  * SQL query binding (for SqlQuery and DtoQuery).
  */
-public interface SpiSqlBinding {
+public interface SpiSqlBinding extends SpiCancelableQuery {
 
   /**
    * Return the named or positioned parameters.

--- a/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
@@ -50,7 +50,7 @@ public final class DtoQueryRequest<T> extends AbstractSqlQueryRequest {
     if (ormQuery != null) {
       ormQuery.setType(type);
       ormQuery.setManualId(true);
-
+      query.setCancelableQuery(ormQuery);
       // execute the underlying ORM query returning the ResultSet
       SpiResultSet result = server.findResultSet(ormQuery, trans);
       this.pstmt = result.getStatement();

--- a/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.core;
 
 import io.ebean.CacheMode;
+import io.ebean.CancelableQuery;
 import io.ebean.OrderBy;
 import io.ebean.PersistenceContextScope;
 import io.ebean.QueryIterator;
@@ -33,7 +34,6 @@ import io.ebeaninternal.server.deploy.DeployParser;
 import io.ebeaninternal.server.deploy.DeployPropertyParserMap;
 import io.ebeaninternal.server.loadcontext.DLoadContext;
 import io.ebeaninternal.server.query.CQueryPlan;
-import io.ebeaninternal.server.query.CancelableQuery;
 import io.ebeaninternal.server.transaction.DefaultPersistenceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/ebeaninternal/server/query/CQuery.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQuery.java
@@ -158,8 +158,6 @@ public class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfileTran
    */
   private PreparedStatement pstmt;
 
-  private boolean cancelled;
-
   private String bindLog;
 
   private final CQueryPlan queryPlan;
@@ -295,7 +293,6 @@ public class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfileTran
   @Override
   public void cancel() {
     synchronized (this) {
-      this.cancelled = true;
       if (pstmt != null) {
         try {
           pstmt.cancel();

--- a/src/main/java/io/ebeaninternal/server/query/CQuery.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQuery.java
@@ -293,14 +293,7 @@ public class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfileTran
   @Override
   public void cancel() {
     synchronized (this) {
-      if (pstmt != null) {
-        try {
-          pstmt.cancel();
-        } catch (SQLException e) {
-          String msg = "Error cancelling query";
-          throw new PersistenceException(msg, e);
-        }
-      }
+      JdbcClose.cancel(pstmt);
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -69,11 +69,13 @@ public class CQueryEngine {
 
   public <T> int delete(OrmQueryRequest<T> request) {
     CQueryUpdate query = queryBuilder.buildUpdateQuery(true, request);
+    request.setCancelableQuery(query);
     return executeUpdate(request, query);
   }
 
   public <T> int update(OrmQueryRequest<T> request) {
     CQueryUpdate query = queryBuilder.buildUpdateQuery(false, request);
+    request.setCancelableQuery(query);
     return executeUpdate(request, query);
   }
 
@@ -100,6 +102,7 @@ public class CQueryEngine {
   public <A> List<A> findSingleAttributeList(OrmQueryRequest<?> request) {
 
     CQueryFetchSingleAttribute rcQuery = queryBuilder.buildFetchAttributeQuery(request);
+    request.setCancelableQuery(rcQuery);
     return findAttributeList(request, rcQuery);
   }
 
@@ -155,6 +158,7 @@ public class CQueryEngine {
   public <A> List<A> findIds(OrmQueryRequest<?> request) {
 
     CQueryFetchSingleAttribute rcQuery = queryBuilder.buildFetchIdsQuery(request);
+    request.setCancelableQuery(rcQuery);
     return findAttributeList(request, rcQuery);
   }
 
@@ -168,6 +172,7 @@ public class CQueryEngine {
   public <T> int findCount(OrmQueryRequest<T> request) {
 
     CQueryRowCount rcQuery = queryBuilder.buildRowCountQuery(request);
+    request.setCancelableQuery(rcQuery);
     try {
 
       int count = rcQuery.findCount();
@@ -272,6 +277,7 @@ public class CQueryEngine {
     query.orderBy().desc(sysPeriodLower);
 
     CQuery<T> cquery = queryBuilder.buildQuery(request);
+    request.setCancelableQuery(cquery);
     try {
       cquery.prepareBindExecuteQuery();
       if (request.isLogSql()) {
@@ -436,6 +442,7 @@ public class CQueryEngine {
 
     CQuery<T> cquery = queryBuilder.buildQuery(request);
 
+    request.setCancelableQuery(cquery);
     try {
       cquery.prepareBindExecuteQuery();
 

--- a/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -244,7 +244,9 @@ public class CQueryEngine {
 
     } catch (SQLException e) {
       try {
-        throw cquery.createPersistenceException(e);
+        PersistenceException pex = cquery.createPersistenceException(e);
+        cquery.close(); // close only when exception occurs
+        throw pex;
       } finally {
         request.rollbackTransIfRequired();
       }
@@ -342,6 +344,7 @@ public class CQueryEngine {
    */
   public <T> SpiResultSet findResultSet(OrmQueryRequest<T> request) {
     CQuery<T> cquery = queryBuilder.buildQuery(request);
+    request.setCancelableQuery(cquery);
     try {
       boolean fwdOnly;
       if (request.isFindIterate()) {

--- a/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.PersistenceException;
-
 /**
  * Base compiled query request for single attribute queries.
  */
@@ -202,14 +200,7 @@ class CQueryFetchSingleAttribute implements SpiProfileTransactionEvent, Cancelab
   @Override
   public void cancel() {
     synchronized (this) {
-      if (pstmt != null) {
-        try {
-          pstmt.cancel();
-        } catch (SQLException e) {
-          String msg = "Error cancelling query";
-          throw new PersistenceException(msg, e);
-        }
-      }
+      JdbcClose.cancel(pstmt);
     }
   }
 }

--- a/src/main/java/io/ebeaninternal/server/query/CQueryRowCount.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryRowCount.java
@@ -166,14 +166,7 @@ class CQueryRowCount implements SpiProfileTransactionEvent, CancelableQuery {
   @Override
   public void cancel() {
     synchronized (this) {
-      if (pstmt != null) {
-        try {
-          pstmt.cancel();
-        } catch (SQLException e) {
-          String msg = "Error cancelling query";
-          throw new PersistenceException(msg, e);
-        }
-      }
+      JdbcClose.cancel(pstmt);
     }
   }
 }

--- a/src/main/java/io/ebeaninternal/server/query/CQueryUpdate.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryUpdate.java
@@ -12,10 +12,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import javax.persistence.PersistenceException;
-
 /**
- * Executes the delete query.
+ * Executes the update query.
  */
 class CQueryUpdate implements SpiProfileTransactionEvent, CancelableQuery {
 
@@ -129,14 +127,7 @@ class CQueryUpdate implements SpiProfileTransactionEvent, CancelableQuery {
   @Override
   public void cancel() {
     synchronized (this) {
-      if (pstmt != null) {
-        try {
-          pstmt.cancel();
-        } catch (SQLException e) {
-          String msg = "Error cancelling query";
-          throw new PersistenceException(msg, e);
-        }
-      }
+      JdbcClose.cancel(pstmt);
     }
   }
 }

--- a/src/main/java/io/ebeaninternal/server/query/DtoQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/DtoQueryEngine.java
@@ -6,6 +6,8 @@ import io.ebeaninternal.server.core.Message;
 import io.ebeaninternal.server.persist.Binder;
 
 import javax.persistence.PersistenceException;
+
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -28,7 +30,7 @@ public class DtoQueryEngine {
       }
       return rows;
 
-    } catch (Throwable e) {
+    } catch (SQLException e) {
       throw new PersistenceException(Message.msg("fetch.error", e.getMessage(), request.getSql()), e);
     } finally {
       request.close();
@@ -41,7 +43,7 @@ public class DtoQueryEngine {
       while (request.next()) {
         consumer.accept(request.readNextBean());
       }
-    } catch (Exception e) {
+    } catch (SQLException e) {
       throw new PersistenceException(Message.msg("fetch.error", e.getMessage(), request.getSql()), e);
 
     } finally {
@@ -57,7 +59,7 @@ public class DtoQueryEngine {
           break;
         }
       }
-    } catch (Exception e) {
+    } catch (SQLException e) {
       throw new PersistenceException(Message.msg("fetch.error", e.getMessage(), request.getSql()), e);
 
     } finally {

--- a/src/main/java/io/ebeaninternal/server/querydefn/AbstractQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/AbstractQuery.java
@@ -1,0 +1,46 @@
+package io.ebeaninternal.server.querydefn;
+
+import javax.persistence.PersistenceException;
+
+import io.ebean.CancelableQuery;
+import io.ebeaninternal.api.SpiCancelableQuery;
+
+/**
+ * Common code for Dto/Orm/RelationalQuery
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class AbstractQuery implements SpiCancelableQuery {
+
+  private boolean cancelled;
+
+  private CancelableQuery cancelableQuery;
+
+  @Override
+  public void cancel() {
+    synchronized (this) {
+      if (!cancelled) {
+        cancelled = true;
+        if (cancelableQuery != null) {
+          cancelableQuery.cancel();
+        }
+      }
+    }
+  }
+
+  @Override
+  public void checkCancelled() {
+    if (cancelled) {
+      throw new PersistenceException("Query was cancelled");
+    }
+  }
+
+  @Override
+  public void setCancelableQuery(CancelableQuery cancelableQuery) {
+    synchronized (this) {
+      checkCancelled();
+      this.cancelableQuery = cancelableQuery;
+    }
+  }
+}

--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
 /**
  * Default implementation of DtoQuery.
  */
-public class DefaultDtoQuery<T> implements SpiDtoQuery<T> {
+public class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQuery<T> {
 
   private final SpiEbeanServer server;
 

--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -861,6 +861,7 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     copy.parentNode = parentNode;
     copy.forUpdate = forUpdate;
     copy.rawSql = rawSql;
+    setCancelableQuery(copy); // required to cancel findId query
     return copy;
   }
 

--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -54,7 +54,6 @@ import io.ebeaninternal.server.deploy.TableJoin;
 import io.ebeaninternal.server.expression.DefaultExpressionList;
 import io.ebeaninternal.server.expression.IdInExpression;
 import io.ebeaninternal.server.expression.SimpleExpression;
-import io.ebeaninternal.server.query.CancelableQuery;
 import io.ebeaninternal.server.query.NativeSqlQueryPlanKey;
 import io.ebeaninternal.server.rawsql.SpiRawSql;
 import io.ebeaninternal.server.transaction.ExternalJdbcTransaction;
@@ -75,7 +74,7 @@ import java.util.function.Predicate;
 /**
  * Default implementation of an Object Relational query.
  */
-public class DefaultOrmQuery<T> implements SpiQuery<T> {
+public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
 
   private static final String DEFAULT_QUERY_NAME = "default";
 
@@ -104,10 +103,6 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   private TableJoin m2mIncludeJoin;
 
   private ProfilingListener profilingListener;
-
-  private boolean cancelled;
-
-  private CancelableQuery cancelableQuery;
 
   private Type type;
 
@@ -1413,6 +1408,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
     return fetch(property, null, FETCH_QUERY);
   }
 
+  @Override
   public Query<T> fetchCache(String property) {
     return fetch(property, null, FETCH_CACHE);
   }
@@ -1965,13 +1961,6 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   }
 
   @Override
-  public void setCancelableQuery(CancelableQuery cancelableQuery) {
-    synchronized (this) {
-      this.cancelableQuery = cancelableQuery;
-    }
-  }
-
-  @Override
   public Query<T> setBaseTable(String baseTable) {
     this.baseTable = baseTable;
     return this;
@@ -1991,23 +1980,6 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   @Override
   public String getAlias() {
     return rootTableAlias;
-  }
-
-  @Override
-  public void cancel() {
-    synchronized (this) {
-      cancelled = true;
-      if (cancelableQuery != null) {
-        cancelableQuery.cancel();
-      }
-    }
-  }
-
-  @Override
-  public boolean isCancelled() {
-    synchronized (this) {
-      return cancelled;
-    }
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
 /**
  * Default implementation of SQuery - SQL Query.
  */
-public class DefaultRelationalQuery implements SpiSqlQuery {
+public class DefaultRelationalQuery extends AbstractQuery implements SpiSqlQuery {
 
   private static final long serialVersionUID = -1098305779779591068L;
 

--- a/src/test/java/org/tests/model/basic/MyEBasicConfigStartup.java
+++ b/src/test/java/org/tests/model/basic/MyEBasicConfigStartup.java
@@ -59,19 +59,19 @@ public class MyEBasicConfigStartup implements ServerConfigStartup {
     @Override
     public void inserted(Object bean) {
       insertCount.incrementAndGet();
-      System.out.println("-- EBasic inserted " + ((EBasic) bean).getId());
+      // System.out.println("-- EBasic inserted " + ((EBasic) bean).getId());
     }
 
     @Override
     public void updated(Object bean, Set<String> updatedProperties) {
       updateCount.incrementAndGet();
-      System.out.println("-- EBasic updated " + ((EBasic) bean).getId() + " updatedProperties: " + updatedProperties);
+      // System.out.println("-- EBasic updated " + ((EBasic) bean).getId() + " updatedProperties: " + updatedProperties);
     }
 
     @Override
     public void deleted(Object bean) {
       deleteCount.incrementAndGet();
-      System.out.println("-- EBasic deleted " + ((EBasic) bean).getId());
+      // System.out.println("-- EBasic deleted " + ((EBasic) bean).getId());
     }
 
   }

--- a/src/test/java/org/tests/query/sqlquery/SlowDownEBasic.java
+++ b/src/test/java/org/tests/query/sqlquery/SlowDownEBasic.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed Materials - Property of FOCONIS AG
+ * (C) Copyright FOCONIS AG.
+ */
+
+package org.tests.query.sqlquery;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.h2.api.Trigger;
+
+import io.ebean.DB;
+import io.ebean.Transaction;
+
+/**
+ * Class to artificially slow down selects. Works only on EBasic.
+ */
+public class SlowDownEBasic implements Trigger {
+
+  private static int wait;
+
+  private static boolean triggerInstalled;
+
+  private static int interruptedCount;
+
+  @Override
+  public void init(final Connection conn, final String schemaName, final String triggerName, final String tableName,
+      final boolean before, final int type) {
+  }
+
+  @Override
+  public void fire(final Connection conn, final Object[] oldRow, final Object[] newRow) {
+    try {
+      Thread.sleep(wait);
+    } catch (InterruptedException e) {
+      interruptedCount++;
+    }
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void remove() {
+  }
+
+  public static int getInterruptedCount() {
+    return interruptedCount;
+  }
+
+  public static void setSelectWaitMillis(final int wait) throws SQLException {
+    SlowDownEBasic.wait = wait;
+    SlowDownEBasic.interruptedCount = 0;
+    if (triggerInstalled) {
+      return;
+    }
+    triggerInstalled = true;
+    try (Transaction txn = DB.beginTransaction(); Statement stmt = txn.getConnection().createStatement()) {
+
+      stmt.execute("CREATE TRIGGER SLOW_DOWN_E_BASIC BEFORE SELECT ON e_basic " + "CALL \""
+          + SlowDownEBasic.class.getName() + "\"");
+      txn.commit();
+    }
+  }
+}

--- a/src/test/java/org/tests/query/sqlquery/SlowDownEBasic.java
+++ b/src/test/java/org/tests/query/sqlquery/SlowDownEBasic.java
@@ -23,8 +23,6 @@ public class SlowDownEBasic implements Trigger {
 
   private static boolean triggerInstalled;
 
-  private static int interruptedCount;
-
   @Override
   public void init(final Connection conn, final String schemaName, final String triggerName, final String tableName,
       final boolean before, final int type) {
@@ -35,7 +33,7 @@ public class SlowDownEBasic implements Trigger {
     try {
       Thread.sleep(wait);
     } catch (InterruptedException e) {
-      interruptedCount++;
+      // nop
     }
   }
 
@@ -47,13 +45,9 @@ public class SlowDownEBasic implements Trigger {
   public void remove() {
   }
 
-  public static int getInterruptedCount() {
-    return interruptedCount;
-  }
 
   public static void setSelectWaitMillis(final int wait) throws SQLException {
     SlowDownEBasic.wait = wait;
-    SlowDownEBasic.interruptedCount = 0;
     if (triggerInstalled) {
       return;
     }

--- a/src/test/java/org/tests/query/sqlquery/SqlQueryCancelTest.java
+++ b/src/test/java/org/tests/query/sqlquery/SqlQueryCancelTest.java
@@ -19,6 +19,8 @@ import io.ebean.DtoQuery;
 import io.ebean.Query;
 import io.ebean.QueryIterator;
 import io.ebean.SqlQuery;
+import io.ebean.annotation.ForPlatform;
+import io.ebean.annotation.Platform;
 
 public class SqlQueryCancelTest extends BaseTestCase {
 
@@ -29,6 +31,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
       DB.save(model);
     }
   }
+
   @Test
   public void cancelSqlQueryAtBegin() {
 
@@ -40,6 +43,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
         .hasMessageContaining("Query was cancelled");
   }
 
+  @ForPlatform(Platform.H2)
   @Test
   public void cancelSqlDuringRun() throws SQLException {
 
@@ -61,6 +65,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
         .hasMessageContaining("Query was cancelled");
   }
 
+  @ForPlatform(Platform.H2)
   @Test
   public void cancelOrmDuringRun() throws SQLException {
 
@@ -70,6 +75,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
       .isInstanceOf(PersistenceException.class)
       .hasCauseInstanceOf(org.h2.jdbc.JdbcSQLTimeoutException.class);
   }
+
   @Test
   public void cancelOrmDuringIterate() throws SQLException {
 
@@ -106,6 +112,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
       this.status = status;
     }
   }
+
   @Test
   public void cancelOrmDtoQueryAtBegin() {
 
@@ -116,6 +123,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
         .hasMessageContaining("Query was cancelled");
   }
 
+  @ForPlatform(Platform.H2)
   @Test
   public void cancelOrmDtoDuringRun() throws SQLException {
 
@@ -136,6 +144,7 @@ public class SqlQueryCancelTest extends BaseTestCase {
         .hasMessageContaining("Query was cancelled");
   }
 
+  @ForPlatform(Platform.H2)
   @Test
   public void cancelSqlDtoDuringRun() throws SQLException {
 

--- a/src/test/java/org/tests/query/sqlquery/SqlQueryCancelTest.java
+++ b/src/test/java/org/tests/query/sqlquery/SqlQueryCancelTest.java
@@ -1,0 +1,183 @@
+package org.tests.query.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+
+import javax.persistence.PersistenceException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tests.model.basic.EBasic;
+import org.tests.model.basic.OrderDetail;
+import org.tests.model.basic.EBasic.Status;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.DtoQuery;
+import io.ebean.Query;
+import io.ebean.QueryIterator;
+import io.ebean.SqlQuery;
+
+public class SqlQueryCancelTest extends BaseTestCase {
+
+  @BeforeClass
+  public static void setupTestData() {
+    for (int i = 0; i < 1000; i++) {
+      EBasic model = new EBasic("Basic " + i);
+      DB.save(model);
+    }
+  }
+  @Test
+  public void cancelSqlQueryAtBegin() {
+
+    String sql = "select * from e_basic";
+    SqlQuery query = DB.createSqlQuery(sql);
+    query.cancel();
+    assertThatThrownBy(query::findList)
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Query was cancelled");
+  }
+
+  @Test
+  public void cancelSqlDuringRun() throws SQLException {
+
+    String sql = "select * from e_basic";
+    SqlQuery query = DB.createSqlQuery(sql);
+    executeDelayed(query::cancel);
+    assertThatThrownBy(query::findList)
+      .isInstanceOf(PersistenceException.class)
+      .hasCauseInstanceOf(org.h2.jdbc.JdbcSQLTimeoutException.class);
+  }
+
+  @Test
+  public void cancelOrmQueryAtBegin() {
+
+    Query<OrderDetail> query = DB.find(OrderDetail.class);
+    query.cancel();
+    assertThatThrownBy(query::findList)
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Query was cancelled");
+  }
+
+  @Test
+  public void cancelOrmDuringRun() throws SQLException {
+
+    Query<EBasic> query = DB.find(EBasic.class);
+    executeDelayed(query::cancel);
+    assertThatThrownBy(query::findList)
+      .isInstanceOf(PersistenceException.class)
+      .hasCauseInstanceOf(org.h2.jdbc.JdbcSQLTimeoutException.class);
+  }
+  @Test
+  public void cancelOrmDuringIterate() throws SQLException {
+
+    Query<EBasic> query = DB.find(EBasic.class);
+
+    QueryIterator<EBasic> iter = query.findIterate();
+    assertThat(iter.hasNext()).isTrue();
+    query.cancel();
+    assertThat(iter.next()).isNotNull();
+
+    assertThatThrownBy(iter::hasNext)
+      .isInstanceOf(PersistenceException.class)
+      .hasMessageContaining("Query was cancelled");
+  }
+
+  public static class BasicDto {
+    private Integer id;
+
+    private Status status;
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public Status getStatus() {
+      return status;
+    }
+
+    public void setStatus(Status status) {
+      this.status = status;
+    }
+  }
+  @Test
+  public void cancelOrmDtoQueryAtBegin() {
+
+    DtoQuery<BasicDto> query = DB.find(EBasic.class).select("id,status").asDto(BasicDto.class);
+    query.cancel();
+    assertThatThrownBy(query::findList)
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Query was cancelled");
+  }
+
+  @Test
+  public void cancelOrmDtoDuringRun() throws SQLException {
+
+    DtoQuery<BasicDto> query = DB.find(EBasic.class).select("id,status").asDto(BasicDto.class);
+    executeDelayed(query::cancel);
+    assertThatThrownBy(query::findList)
+      .isInstanceOf(PersistenceException.class)
+      .hasCauseInstanceOf(org.h2.jdbc.JdbcSQLTimeoutException.class);
+  }
+
+  @Test
+  public void cancelSqlDtoQueryAtBegin() {
+
+    DtoQuery<BasicDto> query = DB.findDto(BasicDto.class, "select id, status from e_basic");
+    query.cancel();
+    assertThatThrownBy(query::findList)
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Query was cancelled");
+  }
+
+  @Test
+  public void cancelSqlDtoDuringRun() throws SQLException {
+
+    DtoQuery<BasicDto> query = DB.findDto(BasicDto.class, "select id, status from e_basic");
+    executeDelayed(query::cancel);
+    assertThatThrownBy(query::findList)
+      .isInstanceOf(PersistenceException.class)
+      .hasCauseInstanceOf(org.h2.jdbc.JdbcSQLTimeoutException.class);
+  }
+
+  private void executeDelayed(Runnable r) throws SQLException {
+    SlowDownEBasic.setSelectWaitMillis(1000);
+    new Thread(() -> {
+      try {
+        Thread.sleep(200);
+        r.run();
+        SlowDownEBasic.setSelectWaitMillis(0);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }).start();
+
+  }
+
+//  @Test
+//  public void findSingleAttributeList_decimal() {
+//
+//    ResetBasicData.reset();
+//
+//    String sql = "select * from o_order_detail";
+//    SqlQuery query = Ebean.createSqlQuery(sql);
+//Thread canceller = new Thread() {
+//  public void run() {
+//    Thread.sleep(200);
+//    query.cancel();
+//  };
+//}
+//
+//    List<BigDecimal> lineAmounts =
+//      .findSingleAttributeList(BigDecimal.class);
+//
+//    assertThat(lineAmounts).isNotEmpty();
+//  }
+
+}


### PR DESCRIPTION
This PR adds a `cancel` method to all types of queries, so that you can cancel them from an other thread