### PR TITLE
Redirect the datasource <mariadbNoemi> to <mariadb103>

### DIFF
--- a/src/test/resources/ebean.properties
+++ b/src/test/resources/ebean.properties
@@ -143,12 +143,12 @@ datasource.mysql.databaseDriver=org.mariadb.jdbc.Driver
 datasource.mysql.initSql=SET NAMES utf8mb4;SET collation_connection = 'utf8mb4_bin';
 ebean.mysql.dataTimeZone=GMT
 
-datasource.mariadbNoemi.username=root
-datasource.mariadbNoemi.password=veryverysecret#1234
-datasource.mariadbNoemi.databaseUrl=jdbc:mariadb://srv-01-docker04.foconis.local:3306/zak_szemenyei_1001
-datasource.mariadbNoemi.databaseDriver=org.mariadb.jdbc.Driver
-datasource.mariadbNoemi.initSql=SET NAMES utf8mb4;SET collation_connection = 'utf8mb4_bin';
-datasource.mariadbNoemi.afterErrorSql=ROLLBACK
+datasource.mariadb103.username=root
+datasource.mariadb103.password=veryverysecret#1234
+datasource.mariadb103.databaseUrl=jdbc:mariadb://srv-01-docker04.foconis.local:3306/ebean_unittest
+datasource.mariadb103.databaseDriver=org.mariadb.jdbc.Driver
+datasource.mariadb103.initSql=SET NAMES utf8mb4;SET collation_connection = 'utf8mb4_bin';
+datasource.mariadb103.afterErrorSql=ROLLBACK
 
 datasource.mariadb.username=ebean
 datasource.mariadb.password=ebean


### PR DESCRIPTION
This change allows to generally run tests against MariaDB 10.3 on internal server.