### PR TITLE
Do not throw BeanHasBeenDeleted on PrimaryKeyJoinColumn

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -880,6 +880,13 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
     return importedPrimaryKey;
   }
 
+  /**
+   * If true, this property references O2O with its primary key.
+   */
+  public boolean isPrimaryKeyExport() {
+    return false;
+  }
+
   @Override
   public boolean isAssocMany() {
     // Returns false - override in BeanPropertyAssocMany.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -365,6 +365,11 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   }
 
   @Override
+  public boolean isPrimaryKeyExport() {
+    return primaryKeyExport;
+  }
+
+  @Override
   public void diff(String prefix, Map<String, ValuePair> map, EntityBean newBean, EntityBean oldBean) {
     Object newEmb = (newBean == null) ? null : getValue(newBean);
     Object oldEmb = (oldBean == null) ? null : getValue(oldBean);
@@ -601,20 +606,28 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
     return findMatch(embeddedProp, prop, prop.dbColumn(), tableJoin);
   }
 
+  /**
+   * If column is a primaryKeyExport colum, we can directly use our own ID and do not need to add a join.
+   * (unless the property is nullable)
+   */
+  boolean requiresJoin() {
+    return !primaryKeyExport || isNullable();
+  }
+
   @Override
   public void appendSelect(DbSqlContext ctx, boolean subQuery) {
     if (!isTransient) {
-      if (primaryKeyExport) {
-        descriptor.idProperty().appendSelect(ctx, subQuery);
-      } else {
+      if (requiresJoin()) {
         localHelp.appendSelect(ctx, subQuery);
+      } else {
+        descriptor.idProperty().appendSelect(ctx, subQuery);
       }
     }
   }
 
   @Override
   public void appendFrom(DbSqlContext ctx, SqlJoinType joinType, String manyWhere) {
-    if (!isTransient && !primaryKeyExport) {
+    if (!isTransient && requiresJoin()) {
       localHelp.appendFrom(ctx, joinType);
       if (sqlFormulaJoin != null) {
         ctx.appendFormulaJoin(sqlFormulaJoin, joinType, manyWhere);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -604,7 +604,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   @Override
   public void appendSelect(DbSqlContext ctx, boolean subQuery) {
     if (!isTransient) {
-      if (primaryKeyExport) {
+      if (primaryKeyExport && !isNullable()) {
         descriptor.idProperty().appendSelect(ctx, subQuery);
       } else {
         localHelp.appendSelect(ctx, subQuery);
@@ -614,7 +614,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
 
   @Override
   public void appendFrom(DbSqlContext ctx, SqlJoinType joinType, String manyWhere) {
-    if (!isTransient && !primaryKeyExport) {
+    if (!isTransient && (!primaryKeyExport || isNullable())) {
       localHelp.appendFrom(ctx, joinType);
       if (sqlFormulaJoin != null) {
         ctx.appendFormulaJoin(sqlFormulaJoin, joinType, manyWhere);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -604,7 +604,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   @Override
   public void appendSelect(DbSqlContext ctx, boolean subQuery) {
     if (!isTransient) {
-      if (primaryKeyExport && !isNullable()) {
+      if (primaryKeyExport) {
         descriptor.idProperty().appendSelect(ctx, subQuery);
       } else {
         localHelp.appendSelect(ctx, subQuery);
@@ -614,7 +614,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
 
   @Override
   public void appendFrom(DbSqlContext ctx, SqlJoinType joinType, String manyWhere) {
-    if (!isTransient && (!primaryKeyExport || isNullable())) {
+    if (!isTransient && !primaryKeyExport) {
       localHelp.appendFrom(ctx, joinType);
       if (sqlFormulaJoin != null) {
         ctx.appendFormulaJoin(sqlFormulaJoin, joinType, manyWhere);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -607,8 +607,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   }
 
   /**
-   * If column is a primaryKeyExport colum, we can directly use our own ID and do not need to add a join.
-   * (unless the property is nullable)
+   * If column is a primaryKeyExport colum, we can directly use our own ID and do not need to add a join if the relation is not optional
    */
   boolean requiresJoin() {
     return !primaryKeyExport || isNullable();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -14,7 +14,6 @@ import io.ebeaninternal.server.deploy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.PersistenceException;
 import java.sql.SQLException;
 import java.util.*;
 
@@ -938,7 +937,10 @@ public final class DefaultPersister implements Persister {
       for (BeanPropertyAssocOne<?> prop : expOnes) {
         // for soft delete check cascade type also supports soft delete
         if (deleteMode.isHard() || prop.isTargetSoftDelete()) {
-          if (request.isLoadedProperty(prop)) {
+          if (prop.isPrimaryKeyExport()) {
+            // we can delete by id, neither if property loaded or not
+            delete(prop.targetDescriptor(), prop.descriptor().id(parentBean), null, t, deleteMode);
+          } else if (request.isLoadedProperty(prop)) {
             Object detailBean = prop.getValue(parentBean);
             if (detailBean != null) {
               deleteRecurse((EntityBean) detailBean, t, deleteMode);

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
@@ -10,7 +10,7 @@ public class OtoBMaster {
 
   String name;
 
-  @OneToOne(cascade = CascadeType.ALL, mappedBy = "master", fetch = FetchType.LAZY)
+  @OneToOne(cascade = CascadeType.ALL, mappedBy = "master", fetch = FetchType.LAZY, optional = false)
   OtoBChild child;
 
   public Long getId() {

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
@@ -10,7 +10,10 @@ public class OtoBMaster {
 
   String name;
 
-  @OneToOne(cascade = CascadeType.ALL, mappedBy = "master", fetch = FetchType.LAZY, optional = false)
+  // BMaster and BChild are both not optional. Note, the DDL contains only a foreign key on oto_bchild
+  // alter table oto_bchild add constraint fk_oto_bchild_master_id foreign key (master_id) references oto_bmaster (id) on delete restrict on update restrict;
+  // So you cannot save a child without it's master, but you can save a master without child (but this would be a violation of the 'optional' contract)
+  @OneToOne(cascade = CascadeType.ALL, mappedBy = "master", fetch = FetchType.LAZY)
   OtoBChild child;
 
   public Long getId() {

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoBMaster.java
@@ -10,9 +10,6 @@ public class OtoBMaster {
 
   String name;
 
-  // BMaster and BChild are both not optional. Note, the DDL contains only a foreign key on oto_bchild
-  // alter table oto_bchild add constraint fk_oto_bchild_master_id foreign key (master_id) references oto_bmaster (id) on delete restrict on update restrict;
-  // So you cannot save a child without it's master, but you can save a master without child (but this would be a violation of the 'optional' contract)
   @OneToOne(cascade = CascadeType.ALL, mappedBy = "master", fetch = FetchType.LAZY)
   OtoBChild child;
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
@@ -1,9 +1,6 @@
 package org.tests.model.onetoone;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import javax.persistence.Version;
+import javax.persistence.*;
 import java.util.UUID;
 
 @Entity
@@ -17,7 +14,7 @@ public class OtoUBPrime {
   /**
    * Master side of bi-directional PrimaryJoinColumn.
    */
-  @OneToOne(mappedBy = "prime")
+  @OneToOne(mappedBy = "prime", optional = false)
   OtoUBPrimeExtra extra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
@@ -14,7 +14,7 @@ public class OtoUBPrime {
   /**
    * Master side of bi-directional PrimaryJoinColumn.
    */
-  @OneToOne(mappedBy = "prime", optional = false)
+  @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY)
   OtoUBPrimeExtra extra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrime.java
@@ -14,7 +14,7 @@ public class OtoUBPrime {
   /**
    * Master side of bi-directional PrimaryJoinColumn.
    */
-  @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "prime", optional = false)
   OtoUBPrimeExtra extra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrimeExtra.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUBPrimeExtra.java
@@ -14,7 +14,7 @@ public class OtoUBPrimeExtra {
   /**
    * Child side of bi-directional PrimaryJoinColumn.
    */
-  @OneToOne
+  @OneToOne(optional = false)
   @PrimaryKeyJoinColumn
   OtoUBPrime prime;
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -17,9 +17,7 @@ public class OtoUPrime {
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is optional so left join to extra.
    */
-  @OneToOne
-  @PrimaryKeyJoinColumn
-  @DbForeignKey(noConstraint = true)
+  @OneToOne(mappedBy = "prime")
   OtoUPrimeExtra extra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -1,7 +1,5 @@
 package org.tests.model.onetoone;
 
-import io.ebean.annotation.DbForeignKey;
-
 import javax.persistence.*;
 import java.util.UUID;
 
@@ -13,6 +11,7 @@ public class OtoUPrime {
 
   String name;
 
+
   /**
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is not optional so use inner join to extra.
@@ -21,8 +20,9 @@ public class OtoUPrime {
    * - you might get a "Beah has been deleted" if lazy load occurs on 'extra'
    */
   @OneToOne(orphanRemoval = true, optional = false)
-  @DbForeignKey(noConstraint = true)
+  @PrimaryKeyJoinColumn
   OtoUPrimeExtra extra;
+
 
   /**
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
@@ -30,7 +30,6 @@ public class OtoUPrime {
    * Setting FetchType.LAZY will NOT add the left join by default to the query.
    */
   @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY, orphanRemoval = true, optional = true)
-  @DbForeignKey(noConstraint = true)
   OtoUPrimeOptionalExtra optionalExtra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -26,7 +26,6 @@ public class OtoUPrime {
   @PrimaryKeyJoinColumn
   OtoUPrimeExtra extra;
 
-
   /**
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is optional so left join to extra.

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -17,7 +17,8 @@ public class OtoUPrime {
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is optional so left join to extra.
    */
-  @OneToOne(mappedBy = "prime")
+  @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY, orphanRemoval = true)
+  //@PrimaryKeyJoinColumn
   OtoUPrimeExtra extra;
 
   @Version

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -22,12 +22,12 @@ public class OtoUPrime {
    * - you might get a "Beah has been deleted" if lazy load occurs on 'extra'
    */
   @OneToOne(orphanRemoval = true, optional = false)
-  @DbForeignKey(noConstraint = true) // enforcing left join - without this, an inner join is used
   @PrimaryKeyJoinColumn
+  // enforcing left join - without 'noConstraint = true', an inner join is used
+  @DbForeignKey(noConstraint = true)
   OtoUPrimeExtra extra;
 
   /**
-   * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is optional so left join to extra.
    * Setting FetchType.LAZY will NOT add the left join by default to the query.
    */

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -20,7 +20,7 @@ public class OtoUPrime {
    * - due the inner join, you might not get results from the query
    * - you might get a "Beah has been deleted" if lazy load occurs on 'extra'
    */
-  @OneToOne(mappedBy = "prime", orphanRemoval = true, optional = false)
+  @OneToOne(orphanRemoval = true, optional = false)
   @DbForeignKey(noConstraint = true)
   OtoUPrimeExtra extra;
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -17,9 +17,13 @@ public class OtoUPrime {
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
    * This OneToOne is optional so left join to extra.
    */
-  @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY, orphanRemoval = true)
-  //@PrimaryKeyJoinColumn
+  @OneToOne(mappedBy = "prime", orphanRemoval = true, optional = false)
+  @DbForeignKey(noConstraint = true)
   OtoUPrimeExtra extra;
+
+  @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY, orphanRemoval = true, optional = true)
+  @DbForeignKey(noConstraint = true)
+  OtoUPrimeOptionalExtra optionalExtra;
 
   @Version
   Long version;
@@ -63,5 +67,13 @@ public class OtoUPrime {
 
   public void setVersion(Long version) {
     this.version = version;
+  }
+
+  public OtoUPrimeOptionalExtra getOptionalExtra() {
+    return optionalExtra;
+  }
+
+  public void setOptionalExtra(OtoUPrimeOptionalExtra optionalExtra) {
+    this.optionalExtra = optionalExtra;
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -1,5 +1,7 @@
 package org.tests.model.onetoone;
 
+import io.ebean.annotation.DbForeignKey;
+
 import javax.persistence.*;
 import java.util.UUID;
 
@@ -14,12 +16,13 @@ public class OtoUPrime {
 
   /**
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
-   * This OneToOne is not optional so use inner join to extra.
+   * This OneToOne is not optional so use inner join to extra (unless DbForeignkey(noConstraint = true) is set)
    * Note: Violating the contract (Storing OtoUPrime without extra) may cause problems:
    * - due the inner join, you might not get results from the query
    * - you might get a "Beah has been deleted" if lazy load occurs on 'extra'
    */
   @OneToOne(orphanRemoval = true, optional = false)
+  @DbForeignKey(noConstraint = true) // enforcing left join - without this, an inner join is used
   @PrimaryKeyJoinColumn
   OtoUPrimeExtra extra;
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrime.java
@@ -15,12 +15,20 @@ public class OtoUPrime {
 
   /**
    * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
-   * This OneToOne is optional so left join to extra.
+   * This OneToOne is not optional so use inner join to extra.
+   * Note: Violating the contract (Storing OtoUPrime without extra) may cause problems:
+   * - due the inner join, you might not get results from the query
+   * - you might get a "Beah has been deleted" if lazy load occurs on 'extra'
    */
   @OneToOne(mappedBy = "prime", orphanRemoval = true, optional = false)
   @DbForeignKey(noConstraint = true)
   OtoUPrimeExtra extra;
 
+  /**
+   * Effectively Ebean automatically sets Cascade PERSIST and mapped by for PrimaryKeyJoinColumn.
+   * This OneToOne is optional so left join to extra.
+   * Setting FetchType.LAZY will NOT add the left join by default to the query.
+   */
   @OneToOne(mappedBy = "prime", fetch = FetchType.LAZY, orphanRemoval = true, optional = true)
   @DbForeignKey(noConstraint = true)
   OtoUPrimeOptionalExtra optionalExtra;

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
@@ -17,9 +17,9 @@ public class OtoUPrimeExtra {
 
   //@OneToOne//(mappedBy = "extra")
   @OneToOne(optional = false)
-  @PrimaryKeyJoinColumn
+  //@PrimaryKeyJoinColumn
   //@DbForeignKey(noConstraint = true)
-  //@Formula(select = "eid") // funktioniert
+  @Formula(select = "${ta}.eid") // funktioniert
   //@JoinColumn(name = "eid")
   private OtoUPrime prime;
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
@@ -1,11 +1,13 @@
 package org.tests.model.onetoone;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Version;
+import io.ebean.annotation.DbForeignKey;
+import io.ebean.annotation.Formula;
+
+import javax.persistence.*;
 import java.util.UUID;
 
 @Entity
+
 public class OtoUPrimeExtra {
 
   @Id
@@ -13,9 +15,20 @@ public class OtoUPrimeExtra {
 
   String extra;
 
+  //@OneToOne//(mappedBy = "extra")
+  @OneToOne(optional = false)
+  @PrimaryKeyJoinColumn
+  //@DbForeignKey(noConstraint = true)
+  //@Formula(select = "eid") // funktioniert
+  //@JoinColumn(name = "eid")
+  private OtoUPrime prime;
+
   @Version
   Long version;
 
+  public OtoUPrimeExtra() {
+
+  }
   public OtoUPrimeExtra(String extra) {
     this.extra = extra;
   }
@@ -47,5 +60,13 @@ public class OtoUPrimeExtra {
 
   public void setVersion(Long version) {
     this.version = version;
+  }
+
+  public OtoUPrime getPrime() {
+    return prime;
+  }
+
+  public void setPrime(OtoUPrime prime) {
+    this.prime = prime;
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtra.java
@@ -6,17 +6,12 @@ import javax.persistence.*;
 import java.util.UUID;
 
 @Entity
-
 public class OtoUPrimeExtra {
 
   @Id
   UUID eid;
 
   String extra;
-
-  @OneToOne(optional = false)
-  @PrimaryKeyJoinColumn
-  private OtoUPrime prime;
 
   @Version
   Long version;
@@ -54,11 +49,4 @@ public class OtoUPrimeExtra {
     this.version = version;
   }
 
-  public OtoUPrime getPrime() {
-    return prime;
-  }
-
-  public void setPrime(OtoUPrime prime) {
-    this.prime = prime;
-  }
 }

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtraWithConstraint.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeExtraWithConstraint.java
@@ -1,0 +1,52 @@
+package org.tests.model.onetoone;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+import java.util.UUID;
+
+@Entity
+public class OtoUPrimeExtraWithConstraint {
+
+  @Id
+  UUID eid;
+
+  String extra;
+
+  @Version
+  Long version;
+
+  public OtoUPrimeExtraWithConstraint(String extra) {
+    this.extra = extra;
+  }
+
+  @Override
+  public String toString() {
+    return "exId:" + eid + " " + extra;
+  }
+
+  public UUID getEid() {
+    return eid;
+  }
+
+  public void setEid(UUID eid) {
+    this.eid = eid;
+  }
+
+  public String getExtra() {
+    return extra;
+  }
+
+  public void setExtra(String extra) {
+    this.extra = extra;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeOptionalExtra.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeOptionalExtra.java
@@ -1,13 +1,10 @@
 package org.tests.model.onetoone;
 
-import io.ebean.annotation.Formula;
-
 import javax.persistence.*;
 import java.util.UUID;
 
 @Entity
-
-public class OtoUPrimeExtra {
+public class OtoUPrimeOptionalExtra {
 
   @Id
   UUID eid;
@@ -21,7 +18,7 @@ public class OtoUPrimeExtra {
   @Version
   Long version;
 
-  public OtoUPrimeExtra(String extra) {
+  public OtoUPrimeOptionalExtra(String extra) {
     this.extra = extra;
   }
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeWithConstraint.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoUPrimeWithConstraint.java
@@ -1,0 +1,63 @@
+package org.tests.model.onetoone;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+public class OtoUPrimeWithConstraint {
+
+  @Id
+  UUID pid;
+
+  String name;
+
+  @OneToOne(orphanRemoval = true, optional = false)
+  // @DbForeignKey(noConstraint = true) see OtoUPrime
+  @PrimaryKeyJoinColumn
+  OtoUPrimeExtraWithConstraint extra;
+
+  @Version
+  Long version;
+
+  public OtoUPrimeWithConstraint(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "id:" + pid + " name:" + name + " extra:" + extra;
+  }
+
+  public UUID getPid() {
+    return pid;
+  }
+
+  public void setPid(UUID pid) {
+    this.pid = pid;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public OtoUPrimeExtraWithConstraint getExtra() {
+    return extra;
+  }
+
+  public void setExtra(OtoUPrimeExtraWithConstraint extra) {
+    this.extra = extra;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
@@ -34,7 +34,7 @@ public class TestOneToOneImportedPkNative extends BaseTestCase {
 
     String sql = sqlOf(query);
     assertThat(sql).contains("select t0.id, t0.name from oto_bmaster t0 where t0.id ");
-    assertThat(sql).doesNotContain("left join oto_bchild");
+    assertThat(sql).doesNotContain("join oto_bchild");
 
     assertThat(one).isNotNull();
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
@@ -46,7 +46,7 @@ public class TestOneToOneImportedPkNative extends BaseTestCase {
 
     List<String> lazyLoadSql = LoggedSql.stop();
     assertThat(lazyLoadSql).hasSize(2);
-    assertSql(lazyLoadSql.get(0)).contains("select t0.id, t0.name, t0.id from oto_bmaster t0 where t0.id = ?");
+    assertSql(lazyLoadSql.get(0)).contains("select t0.id, t0.name, t1.master_id from oto_bmaster t0 left join oto_bchild t1 on t1.master_id = t0.id where t0.id = ?");
     assertSql(lazyLoadSql.get(1)).contains("select t0.master_id, t0.child, t0.master_id from oto_bchild t0 where t0.master_id = ?");
   }
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneImportedPkNative.java
@@ -46,7 +46,7 @@ public class TestOneToOneImportedPkNative extends BaseTestCase {
 
     List<String> lazyLoadSql = LoggedSql.stop();
     assertThat(lazyLoadSql).hasSize(2);
-    assertSql(lazyLoadSql.get(0)).contains("select t0.id, t0.name, t1.master_id from oto_bmaster t0 left join oto_bchild t1 on t1.master_id = t0.id where t0.id = ?");
+    assertSql(lazyLoadSql.get(0)).contains("select t0.id, t0.name, t0.id from oto_bmaster t0 where t0.id = ?");
     assertSql(lazyLoadSql.get(1)).contains("select t0.master_id, t0.child, t0.master_id from oto_bchild t0 where t0.master_id = ?");
   }
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
@@ -45,7 +45,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 left join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
     assertThat(oneWith.getExtra().getExtra()).isEqualTo("v" + desc);

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
@@ -33,7 +33,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime found = query.findOne();
 
     assertThat(found).isNotNull();
-    assertThat(sqlOf(query, 10)).contains("select t0.pid, t0.name, t0.version from oto_ubprime t0 where t0.pid = ?")
+    assertThat(sqlOf(query, 10)).contains("select t0.pid, t0.name, t0.version, t0.pid from oto_ubprime t0 where t0.pid = ?")
       .as("we don't join to oto_ubprime_extra");
 
     assertThat(found.getName()).isEqualTo("u" + desc);
@@ -45,7 +45,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 left join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
     assertThat(oneWith.getExtra().getExtra()).isEqualTo("v" + desc);

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
@@ -33,7 +33,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime found = query.findOne();
 
     assertThat(found).isNotNull();
-    assertThat(sqlOf(query, 10)).contains("select t0.pid, t0.name, t0.version, t0.pid from oto_ubprime t0 where t0.pid = ?")
+    assertThat(sqlOf(query, 10)).contains("select t0.pid, t0.name, t0.version from oto_ubprime t0 where t0.pid = ?")
       .as("we don't join to oto_ubprime_extra");
 
     assertThat(found.getName()).isEqualTo("u" + desc);
@@ -45,7 +45,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 left join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
     assertThat(oneWith.getExtra().getExtra()).isEqualTo("v" + desc);

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -7,6 +7,7 @@ import io.ebean.test.LoggedSql;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,21 +24,34 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
 
   @Test
   public void insertWithoutExtra() {
+    LoggedSql.start();
 
     String desc = "" + System.currentTimeMillis();
     OtoUPrime p1 = new OtoUPrime("u" + desc);
+    //p1.setPid(UUID.randomUUID());
     DB.save(p1);
+
+
+    OtoUPrimeExtra p2 = new OtoUPrimeExtra();
+    //p2.setEid(UUID.randomUUID());
+    p1.setExtra(p2);
+    DB.save(p1);
+
+    DB.find(OtoUPrimeExtra.class).fetch("prime").findList();
 
     Query<OtoUPrime> query = DB.find(OtoUPrime.class)
       .setId(p1.getPid())
-      .fetch("extra", "eid");
+     // .select("pid,name,version")
+      ;
+      //.fetch("extra", "eid");
 
     OtoUPrime found = query.findOne();
 
     if (found.getExtra() != null) {
       found.getExtra().getExtra(); // fails here, because getExtra should be null
     }
-    assertThat(found.getExtra()).isNull();
+   // assertThat(found.getExtra()).isNull();
+    LoggedSql.stop().forEach(System.out::println);
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -69,16 +69,16 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     }
     List<OtoUPrime> primes = query1.findList();
     if (extraFetch && optionalFetch) {
-      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t2.eid, " +
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, " +
         "t1.eid, t1.extra, t1.version, " +
         "t2.eid, t2.extra, t2.version, t2.eid " +
         "from oto_uprime t0 " +
-        "left join oto_uprime_optional_extra t2 on t2.eid = t0.pid " +
-        "left join oto_uprime_extra t1 on t1.eid = t0.pid");
+        "left join oto_uprime_extra t1 on t1.eid = t0.pid " +  // left join on non-optional, because DbForeignKey(noConstraint=true) is set
+        "left join oto_uprime_optional_extra t2 on t2.eid = t0.pid"); // left join on optional
     } else if (extraFetch) {
       assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid");
     } else if (optionalFetch) {
-      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version, t1.eid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_optional_extra t1 on t1.eid = t0.pid");
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_optional_extra t1 on t1.eid = t0.pid");
 
     } else {
       assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version from oto_uprime t0");

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -2,6 +2,7 @@ package org.tests.model.onetoone;
 
 import io.ebean.DB;
 import io.ebean.Query;
+import io.ebean.plugin.Property;
 import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.AfterEach;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,14 +69,14 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     }
     List<OtoUPrime> primes = query1.findList();
     if (extraFetch && optionalFetch) {
-      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t0.pid, t2.eid, " +
-        "t1.eid, t1.extra, t1.version, t1.eid, " +
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t2.eid, " +
+        "t1.eid, t1.extra, t1.version, " +
         "t2.eid, t2.extra, t2.version, t2.eid " +
         "from oto_uprime t0 " +
         "left join oto_uprime_optional_extra t2 on t2.eid = t0.pid " +
         "left join oto_uprime_extra t1 on t1.eid = t0.pid");
     } else if (extraFetch) {
-      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t0.pid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid");
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid");
     } else if (optionalFetch) {
       assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version, t1.eid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_optional_extra t1 on t1.eid = t0.pid");
 
@@ -168,7 +170,8 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     OtoUPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 6)).contains("select t0.pid, t0.name, t0.version, t0.pid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 6))
+      .contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
 
@@ -205,5 +208,14 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     assertSql(sql.get(0)).contains("delete from oto_uprime_extra where");
     assertSql(sql.get(1)).contains("delete from oto_uprime_optional_extra where");
     assertSql(sql.get(2)).contains("delete from oto_uprime where");
+  }
+
+  @Test
+  void testDdl() {
+    Collection<? extends Property> props = DB.getDefault().pluginApi().beanType(OtoUPrime.class).allProperties();
+
+         for (Property prop : props) {
+           System.out.println(prop);
+         }
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -28,17 +28,30 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
 
     String desc = "" + System.currentTimeMillis();
     OtoUPrime p1 = new OtoUPrime("u" + desc);
-    //p1.setPid(UUID.randomUUID());
-    DB.save(p1);
-
-
     OtoUPrimeExtra p2 = new OtoUPrimeExtra();
-    //p2.setEid(UUID.randomUUID());
     p1.setExtra(p2);
     DB.save(p1);
 
+
+    DB.find(OtoUPrime.class).fetch("extra").findList();
     DB.find(OtoUPrimeExtra.class).fetch("prime").findList();
 
+    UUID id = p1.getPid();
+    p1 = DB.find(OtoUPrime.class, id);
+    p2 = DB.find(OtoUPrimeExtra.class, id);
+    assertThat(p1.getPid()).isEqualTo(id);
+    assertThat(p2.getEid()).isEqualTo(id);
+
+    p1.setExtra(null);
+    DB.save(p1);
+    //DB.delete(p2);
+
+    p1 = DB.find(OtoUPrime.class, id);
+    p2 = DB.find(OtoUPrimeExtra.class, id);
+    assertThat(p1).isNotNull();
+    assertThat(p2).isNull();
+
+/*
     Query<OtoUPrime> query = DB.find(OtoUPrime.class)
       .setId(p1.getPid())
      // .select("pid,name,version")
@@ -50,7 +63,7 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     if (found.getExtra() != null) {
       found.getExtra().getExtra(); // fails here, because getExtra should be null
     }
-   // assertThat(found.getExtra()).isNull();
+   // assertThat(found.getExtra()).isNull();*/
     LoggedSql.stop().forEach(System.out::println);
   }
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -1,15 +1,19 @@
 package org.tests.model.onetoone;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Query;
 import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.persistence.PersistenceException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
 
@@ -22,49 +26,120 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     return prime;
   }
 
-  @Test
-  public void insertWithoutExtra() {
-    LoggedSql.start();
+  @BeforeEach
+  void prepare() {
+    OtoUPrime p1Single = new OtoUPrime("Prime without optional");
+    p1Single.setExtra(new OtoUPrimeExtra("Non optional prime required"));
+    DB.save(p1Single);
+
+    OtoUPrimeExtra p2 = new OtoUPrimeExtra("SinglePrimeExtra");
+    try {
+      DB.save(p2);
+      fail("PrimExtra cannot exist without Prime");
+    } catch (PersistenceException pe) {
+
+    }
 
     String desc = "" + System.currentTimeMillis();
     OtoUPrime p1 = new OtoUPrime("u" + desc);
-    OtoUPrimeExtra p2 = new OtoUPrimeExtra();
-    p1.setExtra(p2);
+    p1.setExtra(new OtoUPrimeExtra("u" + desc));
+    p1.setOptionalExtra(new OtoUPrimeOptionalExtra("This one has also an optional"));
     DB.save(p1);
+  }
 
+  @AfterEach
+  void cleanup() {
+    DB.find(OtoUPrime.class).delete();
+    assertThat(DB.find(OtoUPrimeExtra.class).findList()).isEmpty();
+    assertThat(DB.find(OtoUPrimeOptionalExtra.class).findList()).isEmpty();
+  }
 
-    DB.find(OtoUPrime.class).fetch("extra").findList();
-    DB.find(OtoUPrimeExtra.class).fetch("prime").findList();
+  public void doTest1(boolean extraFetch, boolean optionalFetch) {
 
-    UUID id = p1.getPid();
-    p1 = DB.find(OtoUPrime.class, id);
-    p2 = DB.find(OtoUPrimeExtra.class, id);
-    assertThat(p1.getPid()).isEqualTo(id);
-    assertThat(p2.getEid()).isEqualTo(id);
+    // Query for "fetch" case - extra bean joined by left join
 
-    p1.setExtra(null);
-    DB.save(p1);
-    //DB.delete(p2);
-
-    p1 = DB.find(OtoUPrime.class, id);
-    p2 = DB.find(OtoUPrimeExtra.class, id);
-    assertThat(p1).isNotNull();
-    assertThat(p2).isNull();
-
-/*
-    Query<OtoUPrime> query = DB.find(OtoUPrime.class)
-      .setId(p1.getPid())
-     // .select("pid,name,version")
-      ;
-      //.fetch("extra", "eid");
-
-    OtoUPrime found = query.findOne();
-
-    if (found.getExtra() != null) {
-      found.getExtra().getExtra(); // fails here, because getExtra should be null
+    Query<OtoUPrime> query1 = DB.find(OtoUPrime.class);
+    if (extraFetch) {
+      query1.fetch("extra");
     }
-   // assertThat(found.getExtra()).isNull();*/
-    LoggedSql.stop().forEach(System.out::println);
+    if (optionalFetch) {
+      query1.fetch("optionalExtra");
+    }
+    List<OtoUPrime> primes = query1.findList();
+    if (extraFetch && optionalFetch) {
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t0.pid, t2.eid, " +
+        "t1.eid, t1.extra, t1.version, t1.eid, " +
+        "t2.eid, t2.extra, t2.version, t2.eid " +
+        "from oto_uprime t0 " +
+        "left join oto_uprime_optional_extra t2 on t2.eid = t0.pid " +
+        "left join oto_uprime_extra t1 on t1.eid = t0.pid");
+    } else if (extraFetch) {
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.version, t0.pid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid");
+    } else if (optionalFetch) {
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version, t1.eid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_optional_extra t1 on t1.eid = t0.pid");
+
+    } else {
+      assertThat(query1.getGeneratedSql()).isEqualTo("select t0.pid, t0.name, t0.pid, t0.version from oto_uprime t0");
+    }
+
+    List<Long> versions = new ArrayList<>();
+    for (OtoUPrime prime : primes) {
+      if (prime.getOptionalExtra() != null) {
+        versions.add(prime.getOptionalExtra().getVersion());
+      }
+    }
+    assertThat(primes).hasSize(2);
+    assertThat(versions).containsExactly(1L);
+  }
+
+  public void doTest2(boolean withFetch) {
+
+    Query<OtoUPrimeOptionalExtra> query2 = DB.find(OtoUPrimeOptionalExtra.class);
+    if (withFetch) {
+      query2.fetch("prime");
+    }
+    List<OtoUPrimeOptionalExtra> extraPrimes = query2.findList();
+    if (withFetch) {
+      assertThat(query2.getGeneratedSql()).isEqualTo("select t0.eid, t0.extra, t0.version, t1.pid, t1.name, t1.pid, t1.version from oto_uprime_optional_extra t0 join oto_uprime t1 on t1.pid = t0.eid");
+    } else {
+      assertThat(query2.getGeneratedSql()).isEqualTo("select t0.eid, t0.extra, t0.version, t0.eid from oto_uprime_optional_extra t0");
+    }
+    List<Long> versions = new ArrayList<>();
+    for (OtoUPrimeOptionalExtra extraPrime : extraPrimes) {
+      versions.add(extraPrime.getPrime().getVersion());
+    }
+    assertThat(extraPrimes).hasSize(1);
+    assertThat(versions).containsExactly(1L);
+  }
+
+  @Test
+  void testWithExtraFetch1() {
+    doTest1(true, false);
+  }
+
+  @Test
+  void testWithOptionalFetch1() {
+    doTest1(false, true);
+  }
+
+  @Test
+  void testWithBothFetch1() {
+    doTest1(true, true);
+  }
+
+  @Test
+  void testWithoutFetch1() {
+    doTest1(false, false);
+  }
+
+  @Test
+  void testWithFetch2() {
+    doTest2(true);
+  }
+
+  @Test
+  void testWithoutFetch2() {
+    doTest2(false);
   }
 
   @Test
@@ -81,7 +156,7 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     OtoUPrime found = query.findOne();
 
     assertThat(found).isNotNull();
-    assertThat(sqlOf(query, 4)).contains("select t0.pid, t0.name, t0.version, t0.pid from oto_uprime t0 where t0.pid = ?")
+    assertThat(sqlOf(query, 4)).contains("select t0.pid, t0.name, t0.pid, t0.version from oto_uprime t0 where t0.pid = ?")
       .as("we don't join to oto_uprime_extra");
 
     assertThat(found.getName()).isEqualTo("u" + desc);
@@ -93,7 +168,7 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     OtoUPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 6)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 6)).contains("select t0.pid, t0.name, t0.version, t0.pid, t1.eid, t1.extra, t1.version, t1.eid from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
 
@@ -125,8 +200,10 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     DB.delete(bean);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(2);
+
+    assertThat(sql).hasSize(3);
     assertSql(sql.get(0)).contains("delete from oto_uprime_extra where");
-    assertSql(sql.get(1)).contains("delete from oto_uprime where");
+    assertSql(sql.get(1)).contains("delete from oto_uprime_optional_extra where");
+    assertSql(sql.get(2)).contains("delete from oto_uprime where");
   }
 }


### PR DESCRIPTION
When using `@PrimaryKeyJoinColumn` Ebean relies, that the referenced entity exists