### PR TITLE
Transaction API extended with root transaction

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Transaction.java
+++ b/ebean-api/src/main/java/io/ebean/Transaction.java
@@ -561,4 +561,12 @@ public interface Transaction extends AutoCloseable {
    * Get an object added with {@link #putUserObject(String, Object)}.
    */
   Object getUserObject(String name);
+
+  /**
+   * In case of nested transaction, this returns the root transaction.
+   * @return
+   */
+  default Transaction root() {
+    return this;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.api;
 
 import io.ebean.ProfileLocation;
+import io.ebean.Transaction;
 import io.ebean.TransactionCallback;
 import io.ebean.annotation.DocStoreMode;
 import io.ebean.event.changelog.BeanChange;
@@ -456,5 +457,10 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   @Override
   public void postRollback(Throwable cause) {
     transaction.postRollback(cause);
+  }
+
+  @Override
+  public Transaction root() {
+    return transaction.root();
   }
 }

--- a/ebean-test/src/test/java/org/tests/transaction/TestNestedTransaction.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNestedTransaction.java
@@ -257,30 +257,25 @@ public class TestNestedTransaction extends BaseTestCase {
     }
   }
 
-  // 1.63.X Kontrolllauf
   @Test
-  public void test_txn_63() {
+  public void test_txn_putUserObjectInRoot() {
 
     try (Transaction txn1 = DB.beginTransaction(TxScope.requiresNew())) {
-      // executeKontrolle()
-      // ctx.close()
-
-      // BatchProcessor.flush()
       try (Transaction txn2 = DB.beginTransaction()) {
-        // Vorgang.save() --> NotificationCallback, Hinweise sammeln, aber noch kein createNotification
-
-        // WF-Action in JS (Zuständige berechnen und Vorgang zuordnen)
-        // ScriptStatementExecutor.execute
         for (int i = 0; i < 2; i++) {
 
           try (Transaction txn3 = DB.beginTransaction()) {
-            Object x = Transaction.current().getUserObject("x");
+            Object x = Transaction.current().root().getUserObject("x");
+            Object y = Transaction.current().getUserObject("y");
             if (i == 0) {
               assertThat(x).isNull();
+              assertThat(y).isNull();
             } else {
               assertThat(x).isEqualTo(2);
+              assertThat(y).isNull();
             }
-            Transaction.current().putUserObject("x", 2);
+            Transaction.current().root().putUserObject("x", 2);
+            Transaction.current().putUserObject("y", 3);
             txn3.commit();
           }
         }
@@ -289,41 +284,4 @@ public class TestNestedTransaction extends BaseTestCase {
     }
   }
 
-  // 1.62.X Kontrolllauf
-  @Test
-  public void test_txn_62() {
-
-    // TaskRunnable.run()
-    try (Transaction txn0 = DB.beginTransaction()) {
-      //AbstractKontrolllauf.runWithContext()
-      // protocol.runObserved
-      try (Transaction txn1 = DB.beginTransaction(TxScope.mandatory())) {
-        // task.run()
-        // executeKontrolle()
-        // ctx.close()
-
-        // BatchProcessor.flush()
-        try (Transaction txn2 = DB.beginTransaction()) {
-          // Vorgang.save() --> NotificationCallback, Hinweise sammeln, aber noch kein createNotification
-
-          //WF-Action in JS (Zuständige berechnen und Vorgang zuordnen)
-          // ScriptStatementExecutor.execute
-          for (int i = 0; i < 2; i++) {
-
-            try (Transaction txn3 = DB.beginTransaction()) {
-              Object x = Transaction.current().getUserObject("x");
-              if (i == 0) {
-                assertThat(x).isNull();
-              } else {
-                assertThat(x).isEqualTo(2);
-              }
-              Transaction.current().putUserObject("x", 2);
-              txn3.commit();
-            }
-          }
-          txn2.commit();
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Tests zeigen vereinfacht, dass das Zusammenführen der Notifications nicht mehr funktioniert (WF-Actions mit eigener trx3 und put/getUserObject())